### PR TITLE
explicitly uses .div instead of '/'

### DIFF
--- a/lib/hashids.rb
+++ b/lib/hashids.rb
@@ -140,7 +140,7 @@ class Hashids
       ret = "#{pad_left}#{ret}#{pad_right}"
       excess = ret.length - min_length
 
-      ret = ret[(excess/2), min_length] if excess > 0
+      ret = ret[(excess.div(2)), min_length] if excess > 0
       alphabet = consistent_shuffle(alphabet, salt + ret)
     end
 
@@ -235,7 +235,7 @@ class Hashids
 
     while number > 0
       hash   = "#{alphabet[number % alphabet.length]}#{hash}"
-      number = number / alphabet.length
+      number = number.div(alphabet.length)
     end
 
     hash


### PR DESCRIPTION
I have a bit of an odd edge case.  I have a few projects where I always "require 'mathn'" to essentially return more accurate Rational results from numeric calculations in those projects.  Mathn overrides "/" to use #quo instead of #div - returning a Rational instead of a Fixnum

What this meant for hashids.rb is while number > 0 turned into an infinite loop, because numbers < alphabet.length never were 0.

Using .div works great, and I figured I'd pass it along for the incredibly rare individual in the world using both mathn and hashids.
