### PR TITLE
Shuffle performance

### DIFF
--- a/lib/hashids.rb
+++ b/lib/hashids.rb
@@ -142,18 +142,18 @@ class Hashids
 
   def consistent_shuffle(alphabet, salt)
     return alphabet if salt.nil? || salt.empty?
-    v = 0
-    p = 0
-    chars = alphabet.chars.to_a
-    slen = salt.length
+
+    chars = alphabet.each_char.to_a
+    salt_ords = salt.codepoints
+    idx = ord_total = 0
+
     (alphabet.length-1).downto(1) do |i|
-      v  = v % slen
-      p += n = salt[v].ord
-      j  = (n + v + p) % i
+      ord_total += n = salt_ords[idx]
+      j = (n + idx + ord_total) % i
 
       chars[i], chars[j] = chars[j], chars[i]
 
-      v += 1
+      idx = (idx + 1) % salt_ords.length
     end
 
     chars.join

--- a/lib/hashids.rb
+++ b/lib/hashids.rb
@@ -144,7 +144,7 @@ class Hashids
     return alphabet if salt.nil? || salt.empty?
 
     chars = alphabet.each_char.to_a
-    salt_ords = salt.codepoints
+    salt_ords = salt.codepoints.to_a
     idx = ord_total = 0
 
     (alphabet.length-1).downto(1) do |i|

--- a/lib/hashids.rb
+++ b/lib/hashids.rb
@@ -145,6 +145,7 @@ class Hashids
 
     chars = alphabet.each_char.to_a
     salt_ords = salt.codepoints.to_a
+    salt_length = salt_ords.length
     idx = ord_total = 0
 
     (alphabet.length-1).downto(1) do |i|
@@ -153,7 +154,7 @@ class Hashids
 
       chars[i], chars[j] = chars[j], chars[i]
 
-      idx = (idx + 1) % salt_ords.length
+      idx = (idx + 1) % salt_length
     end
 
     chars.join


### PR DESCRIPTION
Approx 12-16% faster encode/decode. 

From #17:
```ruby
hashids = Hashids.new("this is my salt")
hashids2 = Hashids2.new("this is my salt")

Benchmark.ips do |x|
  x.report("before encode") do
    hashids.encode(12345)
  end
  x.report("after encode") do
    hashids2.encode(12345)
  end
  x.compare!
end
Benchmark.ips do |x|
  x.report("before decode") do
    hashids.decode("NkK9")
  end
  x.report("after decode") do
    hashids2.decode("NkK9")
  end
  x.compare!
end
```

MRI 2.4.3 (similar result on 2.5.1):
```
Calculating -------------------------------------
       before encode     42.276k (± 2.3%) i/s -    214.604k in   5.079122s
        after encode     48.071k (± 2.2%) i/s -    242.216k in   5.041219s

Comparison:
        after encode:    48070.8 i/s
       before encode:    42276.5 i/s - 1.14x  slower

Warming up --------------------------------------
       before decode     2.042k i/100ms
        after decode     2.344k i/100ms
Calculating -------------------------------------
       before decode     20.767k (± 2.1%) i/s -    104.142k in   5.017175s
        after decode     23.797k (± 2.0%) i/s -    119.544k in   5.025694s

Comparison:
        after decode:    23796.6 i/s
       before decode:    20766.7 i/s - 1.15x  slower
```